### PR TITLE
Feature 0002: running application on default port 8080

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.application.name=user-service
-server.port=8081
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa


### PR DESCRIPTION
# Overview:
Feature 0002: running application on default port 8080

# Changes made:
- removed server.port property from application.properties file

# Verification Steps:
- Run the Spring Boot application.
- Use Postman to send a GET request to /api/users/{username} to get user information by username and use port number as 8080

# Related Tickets (if applicable):
- N/A

# Review checkList:

- [x] Code compiles without errors.
- [x] Tests are added/updated and pass successfully.
- [x] Linting/formatting rules are followed.
- [x] Documentation is updated (if applicable).

# Merge request type:

- [ ] Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Optimization
- [ ] Documentation
- [ ] Other

# Additional notes:
- N/A